### PR TITLE
feature: create GH pages directory listing

### DIFF
--- a/.github/workflows/directory-listing.yaml
+++ b/.github/workflows/directory-listing.yaml
@@ -1,0 +1,38 @@
+name: directory-listing
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  pages-directory-listing:
+    runs-on: ubuntu-latest
+    name: Directory Listings Index
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Generate Directory Listings
+        uses: jayanta525/github-pages-directory-listing@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: pages-directory-listing
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Add a new GitHub workflow to build a directory listing index and deploy it to the GitHub Pages.